### PR TITLE
Showcase RBAC 

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,5 @@
+# Partial README for RBAC
+
+A user "level1" has been created in the "Helpdesk Org" tenancy. This user has the capability to *ONLY* run a patching report. Simply login with the username "level1" and password "Ansible!23" and you can showcase this RBAC functionality. This can also be a way to show how a manager could get a patch report without having to ask his team for it.
+
+As a next step, you can then login as the admin and showcase the patching template that includes the survey etc.

--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -291,7 +291,9 @@ controller_templates:
 controller_roles:
   - projects:
       - "Ansible official demo project"
-    job_templates:
-        - "WINDOWS / Patching Report"
+    user: level1
+    role: use
+  - job_templates:
+      - "WINDOWS / Patching Report"
     user: level1
     role: execute

--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -106,6 +106,7 @@ controller_templates:
     survey_enabled: false
     extra_vars:
       HOSTS: student1-win1
+      report_server: student1-win1
       win_update_categories:
         - Application
         - Connectors

--- a/windows/setup.yml
+++ b/windows/setup.yml
@@ -3,8 +3,21 @@ user_message: |
   ''
 
 controller_components:
+  - organizations
+  - users
   - projects
   - job_templates
+  - roles
+
+controller_organizations:
+- name: "Helpdesk Org"
+  description: This is the Helpdesk
+
+controller_user_accounts:
+  - user: level1
+    is_superuser: false
+    password: Ansible!23
+    organization: "Helpdesk Org"
 
 controller_projects:
   - name: Fact Scan
@@ -79,6 +92,33 @@ controller_templates:
           choices:
             - 'Yes'
             - 'No'
+
+  - name: "WINDOWS / Patching Report"
+    use_fact_cache: true
+    job_type: check
+    ask_job_type_on_launch: no
+    inventory: "Workshop Inventory"
+    project: "Ansible official demo project"
+    playbook: "windows/patching.yml"
+    execution_environment: Default execution environment
+    credentials:
+    - "Workshop Credential"
+    survey_enabled: false
+    extra_vars:
+      HOSTS: student1-win1
+      win_update_categories:
+        - Application
+        - Connectors
+        - CriticalUpdates
+        - DefinitionUpdates
+        - DeveloperKits
+        - FeaturePacks Guidance
+        - SecurityUpdates
+        - ServicePacks
+        - Tools
+        - UpdateRollups
+        - Updates
+      allow_reboot: 'No'
 
   - name: "WINDOWS / Chocolatey install multiple"
     job_type: run
@@ -245,3 +285,12 @@ controller_templates:
           variable: telephone_number
           default: 555-123456
           required: false
+
+
+controller_roles:
+  - projects:
+      - "Ansible official demo project"
+    job_templates:
+        - "WINDOWS / Patching Report"
+    user: level1
+    role: execute


### PR DESCRIPTION
This PR adds a new organization and a user with execute only access to run a patch report. There is a small README to help demo this feature.

I'm not sure if the patching report logic only displays the components that require patching (it appears that way to me). It might make sense to update the patching report to include component being requested for with a "Compliant" status if they don't require patching. FYI, the template I'm using for running the patching report is as follows :: 

```
  - name: "WINDOWS / Patching Report"
    use_fact_cache: true
    job_type: check
    ask_job_type_on_launch: no
    inventory: "Workshop Inventory"
    project: "Ansible official demo project"
    playbook: "windows/patching.yml"
    execution_environment: Default execution environment
    credentials:
    - "Workshop Credential"
    survey_enabled: false
    extra_vars:
      HOSTS: student1-win1
      report_server: student1-win1
      win_update_categories:
        - Application
        - Connectors
        - CriticalUpdates
        - DefinitionUpdates
        - DeveloperKits
        - FeaturePacks Guidance
        - SecurityUpdates
        - ServicePacks
        - Tools
        - UpdateRollups
        - Updates
      allow_reboot: 'No'
```



