### PR TITLE
Corrected hostnames for patching playbook

### DIFF
--- a/windows/patching.yml
+++ b/windows/patching.yml
@@ -1,6 +1,6 @@
 ---
 - name: Windows updates
-  hosts: "{{ HOSTS | default('os_windows') }}"
+  hosts: "{{ HOSTS | default('windows') }}"
   vars:
     report_server: win1
   

--- a/windows/patching.yml
+++ b/windows/patching.yml
@@ -2,7 +2,7 @@
 - name: Windows updates
   hosts: "{{ HOSTS | default('windows') }}"
   vars:
-    report_server: win1
+    report_server: student1-win1
   
   tasks:
   - include_role:


### PR DESCRIPTION
- Corrected hostnames to fit the demo environment. "os_windows" and "win1" do not exist there.