### PR TITLE
Added a python to python3 sym link

### DIFF
--- a/collections/ansible_collections/demo/patching/roles/patch_linux/tasks/main.yml
+++ b/collections/ansible_collections/demo/patching/roles/patch_linux/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Ensure python simlink exists
+  ansible.builtin.file:
+    src: /usr/bin/python3
+    dest: /usr/bin/python
+    state: link
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_python_version != "2.7.5"
+
 - name: Scan packages
   demo.patching.scan_packages:
     os_family: "{{ ansible_os_family }}"


### PR DESCRIPTION
Playbook will fail on any VMs running only python3, this symlink will fix the errors with the scan_packages module