### PR TITLE
Increased the Idle Time Force Log Out

### DIFF
--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -11,6 +11,7 @@
         controller_components:
           - notification_templates
           - job_templates
+          - settings
         controller_notifications:
           - name: Telemetry
             organization: Default
@@ -42,6 +43,9 @@
                   type: textarea
                   variable: feedback
                   required: true
+        controller_settings:
+          - name: "AUTH_SESSION_COOKIE_AGE"
+            value: 180000
 
     - name: "include configuration for {{ demo }}"
       include_vars: "{{demo}}/setup.yml"
@@ -52,12 +56,6 @@
       loop: "{{ controller_components }}"
       when:
         - controller_components | d("") | length > 0
-
-    - name: Increase Idle Time Force Log Out
-      include_role:
-        name: "redhat_cop.controller_configuration.settings"
-          settings:
-            AUTH_SESSION_COOKIE_AGE: 180000
 
     - name: Log Demo
       ansible.builtin.uri:

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -56,8 +56,8 @@
     - name: Increase Idle Time Force Log Out
       include_role:
         name: "redhat_cop.controller_configuration.settings"
-          - name: AUTH_SESSION_COOKIE_AGE
-            value: 180000
+          settings:
+            AUTH_SESSION_COOKIE_AGE: 180000
 
     - name: Log Demo
       ansible.builtin.uri:

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -53,6 +53,12 @@
       when:
         - controller_components | d("") | length > 0
 
+    - name: Increase Idle Time Force Log Out
+      include_role:
+        name: "redhat_cop.controller_configuration.settings"
+          - name: AUTH_SESSION_COOKIE_AGE
+            value: 180000
+
     - name: Log Demo
       ansible.builtin.uri:
         url: https://docs.google.com/forms/d/e/1FAIpQLSdIZ77YpETjEfGOoYlXtMnQiU-6M7QFlb2hJA4ujo25QYb2jw/formResponse

--- a/setup_demo.yml
+++ b/setup_demo.yml
@@ -44,7 +44,7 @@
                   variable: feedback
                   required: true
         controller_settings:
-          - name: "AUTH_SESSION_COOKIE_AGE"
+          - name: "SESSION_COOKIE_AGE"
             value: 180000
 
     - name: "include configuration for {{ demo }}"


### PR DESCRIPTION
Increasing Idle Time Force Log Out removes the issue of a session timing out during customer facing activity. This PR increases the timeout to an arbitrarily high amount.

Verified working
![image](https://user-images.githubusercontent.com/28571284/196244321-361ff2bf-8a50-4e8e-aebb-8c6804d0816b.png)
