### PR TITLE
Run insights scan (skip errors if not configured) (Issue #32)

### DIFF
--- a/linux/patching.yml
+++ b/linux/patching.yml
@@ -8,7 +8,7 @@
   - include_role:
       name: demo.patching.patch_linux
 
-  - name: Tell user when Insights is not configured
+  - name: Tell user when Insights Client is not configured
     debug:
       msg: "Insights client does not appear to be configured. Scan will be skipped"
     when:

--- a/linux/patching.yml
+++ b/linux/patching.yml
@@ -8,10 +8,16 @@
   - include_role:
       name: demo.patching.patch_linux
 
+  - name: Tell user when Insights is not configured
+    msg: "Insights client does not appear to be configured. Scan will be skipped"
+    when:
+      - ansible_local.insights.system_id is not defined
+
   - name: Run the Insights Client Scan
     command: insights-client
-    ignore_errors: yes
-    when: not ansible_check_mode
+    when:
+      - not ansible_check_mode
+      - ansible_local.insights.system_id is defined
 
   - block:
 

--- a/linux/patching.yml
+++ b/linux/patching.yml
@@ -9,7 +9,8 @@
       name: demo.patching.patch_linux
 
   - name: Tell user when Insights is not configured
-    msg: "Insights client does not appear to be configured. Scan will be skipped"
+    debug:
+      msg: "Insights client does not appear to be configured. Scan will be skipped"
     when:
       - ansible_local.insights.system_id is not defined
 

--- a/linux/patching.yml
+++ b/linux/patching.yml
@@ -8,6 +8,11 @@
   - include_role:
       name: demo.patching.patch_linux
 
+  - name: Run the Insights Client Scan
+    command: insights-client
+    ignore_errors: yes
+    when: not ansible_check_mode
+
   - block:
 
     - include_role:


### PR DESCRIPTION
Quick and easy fix to call `insights-client` after the patching run to update info.  Ignores errors so it can handle cases where the host isn't registered to Insights.