### PR TITLE
Added Insights Compliance Scan (Issue #49)

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -26,7 +26,8 @@ This category of demos shows examples of linux operations and management with An
 - [**Linux / Fact Scan**](https://github.com/ansible/awx-facts-playbooks/blob/master/scan_facts.yml) - Run a fact, package, and service scan against a system and store in fact cache
 - [**Linux / Podman Webserver**](podman.yml) - Install and run a Podman webserver with given text on the home page
 - [**Linux / System Roles**](system_roles.yml) - Apply Linux system roles to servers. Must provide variables and role names.
-- [**Linux / Compliance**](compliance.yml) - Apply remediation to meet the requirements of a compliance baseline
+- [**Linux / Compliance Enforce**](compliance.yml) - Apply remediation to meet the requirements of a compliance baseline
+- [**Linux / Insights Compliance Scan**](insights_compliance_scan.yml) - Run a Compliance scan based on the configuration in [Red Hat Insights][https://console.redhat.com]
 
 ### Inventory
 
@@ -73,3 +74,5 @@ system_roles:
 selinux_state: enforcing
 ```
 **Linux / Compliance** - Apply compliance profile hardening configuration from [here](https://galaxy.ansible.com/RedHatOfficial). BE AWARE: this could have unintended results based on the current state of your machine. Always test on a single machine before distributing at scale. For example, AWS instances have NOPASSWD allowed for sudo. Running STIG compliance without adding `sudo_remove_nopasswd: false` to extra_vars on the job template will lock you out of the machine. This variable is configured on the job template by default for this reason.
+
+**Linux / Insights Compliance Scan** - Scan the system according to the compliance profile configured via [Red Hat Insights](https://console.redhat.com). NOTE: This job will fail if the systems haven't been registered with Insights and associated with a relevant compliance profile. A survey when running the job will ask if you have configured all systems with a compliance profile, and effectively skip all tasks in the job template if the answer is "No".

--- a/linux/insights_compliance_scan.yml
+++ b/linux/insights_compliance_scan.yml
@@ -1,0 +1,24 @@
+---
+- hosts: "{{ HOSTS }}"
+  become: true
+  vars:
+    #compliance_profile: undef
+
+  tasks:
+    - name: Check OS Type
+      assert:
+        that: "ansible_os_family == 'RedHat'"
+
+    - name: Check variable values
+      debug:
+        msg: "Value of compliance_profile_configured is {{ compliance_profile_configured }}"
+
+    - name: Run Insights Compliance scan
+      import_role:
+        name: redhat.insights.compliance
+      when: compliance_profile_configured == "Yes"
+
+    - name: Notify user that Compliance scan is not being attempted
+      debug:
+        msg: "User has not confirmed that all hosts are associated with an Insights Compliance profile. Scan aborted."
+      when: compliance_profile_configured == "No"

--- a/linux/setup.yml
+++ b/linux/setup.yml
@@ -292,7 +292,7 @@ controller_templates:
           variable: HOSTS
           required: true
 
-  - name: "LINUX / Compliance"
+  - name: "LINUX / Compliance Enforce"
     job_type: run
     inventory: "Workshop Inventory"
     project: "Ansible official demo project"
@@ -319,3 +319,28 @@ controller_templates:
           required: true
           choices:
             - stig
+
+  - name: "LINUX / Insights Compliance Scan"
+    job_type: run
+    inventory: "Workshop Inventory"
+    project: "Ansible official demo project"
+    playbook: "linux/insights_compliance_scan.yml"
+    credentials:
+    - "Workshop Credential"
+    survey_enabled: true
+    survey:
+      name: ''
+      description: ''
+      spec:
+        - question_name: Server Name or Pattern
+          type: text
+          variable: HOSTS
+          required: true
+        - question_name: Have you associated a compliance profile in the Insights Console for all hosts to be scanned?  If not, then the scan will fail.
+          type: multiplechoice
+          variable: compliance_profile_configured
+          required: true
+          choices:
+            - "Yes"
+            - "No"
+          default: "No"


### PR DESCRIPTION
Added new template for an Insights compliance scan, which depends on Insights being configured by the LINUX / Register job, and a compliance profile considered in the Insights UI.  Has some simple logic to warn the user if they haven't done the above.  Fixes RFE #49 