### PR TITLE
Fix selinux variables

### DIFF
--- a/linux/setup.yml
+++ b/linux/setup.yml
@@ -289,7 +289,8 @@ controller_templates:
     extra_vars:
       system_roles:
         - selinux
-      selinux_policy: enforcing
+      selinux_policy: targeted
+      selinux_state: enforcing
     credentials:
     - "Workshop Credential"
     survey_enabled: true


### PR DESCRIPTION
Per bugzuilla ticket... _the valid values for "policy" are "targeted" or some sort of policy ("mls"?), and for "state" are "disabled", "permissive", or "enforcing"_

This PR updates the values to match the correct usage of the module and closes #65 